### PR TITLE
Alteracion para que no suene salto y posicion de texto nivel 3

### DIFF
--- a/core/src/com/itesm/magmaescape/PantallaMenu.java
+++ b/core/src/com/itesm/magmaescape/PantallaMenu.java
@@ -5,6 +5,7 @@ Autor: Norma P Iturbide
 */
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -25,6 +26,7 @@ public class PantallaMenu extends Pantalla {
 
     public void show() {
         this.crearMenu();
+        Gdx.input.setCatchKey(Input.Keys.BACK, false);
     }
 
     private void crearMenu() {

--- a/core/src/com/itesm/magmaescape/PantallaNivel1.java
+++ b/core/src/com/itesm/magmaescape/PantallaNivel1.java
@@ -346,7 +346,7 @@ public class PantallaNivel1 extends Pantalla {
 
             }
 
-            if (estadoJuego==EstadoJuego.JUGANDO && estadoOlivia != com.itesm.magmaescape.EstadoOlivia.MURIENDO){
+            if (estadoJuego==EstadoJuego.JUGANDO && estadoOlivia != com.itesm.magmaescape.EstadoOlivia.MURIENDO && (int)tiempo<30){
                 olivia.saltar(); // Top-Down
             }
 

--- a/core/src/com/itesm/magmaescape/PantallaNivel2.java
+++ b/core/src/com/itesm/magmaescape/PantallaNivel2.java
@@ -499,7 +499,7 @@ public class PantallaNivel2 extends Pantalla {
 
             }else
 
-            if (estadoOlivia != com.itesm.magmaescape.EstadoOlivia.PAUSA && estadoOlivia != com.itesm.magmaescape.EstadoOlivia.MURIENDO ){
+            if (estadoOlivia != com.itesm.magmaescape.EstadoOlivia.PAUSA && estadoOlivia != com.itesm.magmaescape.EstadoOlivia.MURIENDO && (int)tiempo<60 ){
 
                 olivia.saltar(); // Top-Down
             }

--- a/core/src/com/itesm/magmaescape/PantallaNivel3.java
+++ b/core/src/com/itesm/magmaescape/PantallaNivel3.java
@@ -307,8 +307,8 @@ public class PantallaNivel3 extends Pantalla {
 
         if(estadoInvencibilidad== com.itesm.magmaescape.EstadoInvencibilidad.INVENCIBILIDAD_ACTIVADA && txt!=null)
         {
-            txt.mostrarMensaje(batch,"Invencibilidad",ANCHO*.13F,.65F*ALTO);
-            txt.mostrarMensaje(batch,"Activada "+(10-(int)(tiempoInv)),ANCHO*.13F,.60F*ALTO);
+            txt.mostrarMensaje(batch,"Invencibilidad",ANCHO*.17F,.70F*ALTO);
+            txt.mostrarMensaje(batch,"Activada "+(10-(int)(tiempoInv)),ANCHO*.17F,.65F*ALTO);
         }
 
         if(estadoLentitud== com.itesm.magmaescape.EstadoLentitud.LENTITUD_ACTIVADA&& txtLEN!=null)
@@ -739,7 +739,7 @@ public class PantallaNivel3 extends Pantalla {
             }else
 
 
-            if (estadoJuego==EstadoJuego.JUGANDO && estadoOlivia != com.itesm.magmaescape.EstadoOlivia.MURIENDO ){
+            if (estadoJuego==EstadoJuego.JUGANDO && estadoOlivia != com.itesm.magmaescape.EstadoOlivia.MURIENDO && (int)tiempo<90){
 
                 olivia.saltar(); // Top-Down
 


### PR DESCRIPTION
El sonido de saltar ya no suena despues de ganar y el texto de invencibilidad en el nivel 3 estaba cortado fue movido mas a la derecha y mas arriba